### PR TITLE
Add (in)active orders endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Handle:
 - list stores (`/api/item/`)
 - get a store (`/api/item/:id`)
 - set favorite (`/api/item/:id/setFavorite`)
+- get active orders (`/api/order/vX/active`)
+- get inactive orders (`/api/order/vX/inactive`)
 
 Used by:
 - https://tgtg-notifier.com
@@ -348,6 +350,51 @@ client.get_item(item_id=64346)
 ```
 
 </details>
+
+### Get active orders
+
+```python
+client.get_active()
+```
+
+### Get inactive orders
+
+```python
+client.get_inactive(page=0, page_size=20)
+
+# returned object has `has_more` property if more results are available
+```
+
+To e.g. sum up all orders you have ever made:
+
+```python
+    orders = []
+    page = 0
+    while inactive := client.get_inactive(page=page, page_size=200):
+        orders += inactive["orders"]
+        if not inactive["has_more"]:
+            break
+
+    redeemed_orders = [x for x in orders if x["state"] == "REDEEMED"]
+    redeemed_items = sum([x["quantity"] for x in redeemed_orders])
+
+    # if you bought in multiple currencies this will need improvements
+    money_spend = sum(
+        [
+            x["price_including_taxes"]["minor_units"]
+            / (10 ** x["price_including_taxes"]["decimals"])
+            for x in redeemed_orders
+        ]
+    )
+
+    print(f"Total numbers of orders: {len(orders)}")
+    print(f"Total numbers of picked up orders: {len(redeemed_orders)}")
+    print(f"Total numbers of items picked up: {redeemed_items}")
+    print(
+        f"Total money spend: ~{money_spend:.2f}{redeemed_orders[0]['price_including_taxes']['code']}"
+    )
+```
+
 
 ### Set favorite
 *(Using item_id from get_items response)*

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -1,0 +1,69 @@
+from urllib.parse import urljoin
+
+import pytest
+import responses
+
+from tgtg import ACTIVE_ORDER_ENDPOINT, BASE_URL, INACTIVE_ORDER_ENDPOINT, TgtgClient
+from tgtg.exceptions import TgtgAPIError
+
+from .constants import tgtg_client_fake_tokens
+
+
+def test_get_active_success(refresh_tokens_response):
+    responses.add(
+        responses.POST,
+        urljoin(BASE_URL, ACTIVE_ORDER_ENDPOINT),
+        json={"orders": []},
+        status=200,
+    )
+    client = TgtgClient(**tgtg_client_fake_tokens)
+    assert client.get_active()["orders"] == []
+    assert (
+        len(
+            [
+                call
+                for call in responses.calls
+                if ACTIVE_ORDER_ENDPOINT in call.request.url
+            ]
+        )
+        == 1
+    )
+
+
+def test_get_active_fail(refresh_tokens_response):
+    responses.add(
+        responses.POST, urljoin(BASE_URL, ACTIVE_ORDER_ENDPOINT), json={}, status=400
+    )
+    client = TgtgClient(**tgtg_client_fake_tokens)
+    with pytest.raises(TgtgAPIError):
+        client.get_active()
+
+
+def test_get_inactive_success(refresh_tokens_response):
+    responses.add(
+        responses.POST,
+        urljoin(BASE_URL, INACTIVE_ORDER_ENDPOINT),
+        json={"orders": []},
+        status=200,
+    )
+    client = TgtgClient(**tgtg_client_fake_tokens)
+    assert client.get_inactive()["orders"] == []
+    assert (
+        len(
+            [
+                call
+                for call in responses.calls
+                if INACTIVE_ORDER_ENDPOINT in call.request.url
+            ]
+        )
+        == 1
+    )
+
+
+def test_get_inactive_fail(refresh_tokens_response):
+    responses.add(
+        responses.POST, urljoin(BASE_URL, INACTIVE_ORDER_ENDPOINT), json={}, status=400
+    )
+    client = TgtgClient(**tgtg_client_fake_tokens)
+    with pytest.raises(TgtgAPIError):
+        client.get_inactive()

--- a/tgtg/__init__.py
+++ b/tgtg/__init__.py
@@ -14,6 +14,8 @@ AUTH_BY_EMAIL_ENDPOINT = "auth/v3/authByEmail"
 AUTH_POLLING_ENDPOINT = "auth/v3/authByRequestPollingId"
 SIGNUP_BY_EMAIL_ENDPOINT = "auth/v3/signUpByEmail"
 REFRESH_ENDPOINT = "auth/v3/token/refresh"
+ACTIVE_ORDER_ENDPOINT = "order/v6/active"
+INACTIVE_ORDER_ENDPOINT = "order/v6/inactive"
 USER_AGENTS = [
     "TGTG/21.9.3 Dalvik/2.1.0 (Linux; U; Android 6.0.1; Nexus 5 Build/M4B30Z)",
     "TGTG/21.9.3 Dalvik/2.1.0 (Linux; U; Android 7.0; SM-G935F Build/NRD90M)",
@@ -291,5 +293,33 @@ class TgtgClient:
                 "user_id"
             ]
             return self
+        else:
+            raise TgtgAPIError(response.status_code, response.content)
+
+    def get_active(self):
+        self.login()
+        response = self.session.post(
+            self._get_url(ACTIVE_ORDER_ENDPOINT),
+            headers=self._headers,
+            json={"user_id": self.user_id},
+            proxies=self.proxies,
+            timeout=self.timeout,
+        )
+        if response.status_code == HTTPStatus.OK:
+            return response.json()
+        else:
+            raise TgtgAPIError(response.status_code, response.content)
+
+    def get_inactive(self, page=0, page_size=20):
+        self.login()
+        response = self.session.post(
+            self._get_url(INACTIVE_ORDER_ENDPOINT),
+            headers=self._headers,
+            json={"paging": {"page": page, "size": page_size}, "user_id": self.user_id},
+            proxies=self.proxies,
+            timeout=self.timeout,
+        )
+        if response.status_code == HTTPStatus.OK:
+            return response.json()
         else:
             raise TgtgAPIError(response.status_code, response.content)


### PR DESCRIPTION
Add orders endpoint for active and inactive orders.

Nice to see if there are any open orders, or to see how much stuff you bought recently.