### PR TITLE
align TgtgAPIError args for 429 with other TgtgAPIErrors

### DIFF
--- a/tgtg/__init__.py
+++ b/tgtg/__init__.py
@@ -143,7 +143,9 @@ class TgtgClient:
                     raise TgtgLoginError(response.status_code, response.content)
             else:
                 if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-                    raise TgtgAPIError(response.status_code, "Too many requests. Try again later.")
+                    raise TgtgAPIError(
+                        response.status_code, "Too many requests. Try again later."
+                    )
                 else:
                     raise TgtgLoginError(response.status_code, response.content)
 
@@ -177,7 +179,9 @@ class TgtgClient:
                 return
             else:
                 if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-                    raise TgtgAPIError(response.status_code, "Too many requests. Try again later.")
+                    raise TgtgAPIError(
+                        response.status_code, "Too many requests. Try again later."
+                    )
                 else:
                     raise TgtgLoginError(response.status_code, response.content)
 

--- a/tgtg/__init__.py
+++ b/tgtg/__init__.py
@@ -142,8 +142,8 @@ class TgtgClient:
                 else:
                     raise TgtgLoginError(response.status_code, response.content)
             else:
-                if response.status_code == 429:
-                    raise TgtgAPIError("429 - Too many requests. Try again later.")
+                if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
+                    raise TgtgAPIError(response.status_code, "Too many requests. Try again later.")
                 else:
                     raise TgtgLoginError(response.status_code, response.content)
 
@@ -177,7 +177,7 @@ class TgtgClient:
                 return
             else:
                 if response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
-                    raise TgtgAPIError("429 - Too many requests. Try again later.")
+                    raise TgtgAPIError(response.status_code, "Too many requests. Try again later.")
                 else:
                     raise TgtgLoginError(response.status_code, response.content)
 


### PR DESCRIPTION
I noted that the args for the `TgtgAPIError` are not allways the same.