### PR TITLE
Bump to 0.11.1 to correct requests dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tgtg"
-version = "0.11.0"
+version = "0.11.1"
 description = "Unoffical python client for TooGoodToGo API"
 readme = "README.md"
 authors = ["Anthony Hivert <anthony.hivert@gmail.com>"]


### PR DESCRIPTION
Hi,

The installation of my [Home Assistant module](https://github.com/Chouffy/home_assistant_tgtg/) breaks in the latest beta version of Home Assistant (2022.2.3.0b1 - [see detailed ticket here](https://github.com/Chouffy/home_assistant_tgtg/issues/25)). This is due to dependency conflicts.

Thanks to one of the user, I pinpointed that this is due to the `requests` module version:
* In Home Assistant, `requests==2.27.1` - [source](https://github.com/home-assistant/core/blob/e9496869da79ffca49a651b39404c462f675fafc/requirements.txt#L21)
* In this module `tgtg` at tag 0.11.0, `requests = "2.26.0"` - [source](https://github.com/ahivert/tgtg-python/blob/91f80de54a25cc7b4667a82ff9a21ce07b4eac1a/pyproject.toml#L11)

Hence the dependency conflict.

The `requests` package was [already updated by dependabot](https://github.com/ahivert/tgtg-python/pull/144), so we would just need to publish this change in a new `tgtg` tag published on PyPI.
So this PR is just bumping the tag, and hopefully this repo author can approve it and publish it :)

Thanks!