### PR TITLE
Bump requests to 2.28.0 to be compatible with Home Assistant

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -340,7 +340,7 @@ python-versions = "*"
 
 [[package]]
 name = "requests"
-version = "2.27.1"
+version = "2.28.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false


### PR DESCRIPTION
Hi,

Similar to [this issue](https://github.com/ahivert/tgtg-python/pull/155), the `requests` package need to be updated to 2.28.0 to cohabit with Home Assistant.
Otherwise, the installation of the [Home Assistant integration](https://github.com/Chouffy/home_assistant_tgtg) fails.

Thanks!