### PR TITLE
Bump request to 2.28.0 and tgtg to 0.11.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tgtg"
-version = "0.11.3"
+version = "0.11.4"
 description = "Unoffical python client for TooGoodToGo API"
 readme = "README.md"
 authors = ["Anthony Hivert <anthony.hivert@gmail.com>"]
@@ -8,7 +8,7 @@ repository = "https://github.com/ahivert/tgtg-python"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-requests = "2.27.1"
+requests = "2.28.0"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Hi,

Similar to [this issue](https://github.com/ahivert/tgtg-python/pull/155), the `requests` package need to be updated to 2.28.0 to cohabit with Home Assistant.
Otherwise, the installation of the [Home Assistant integration](https://github.com/Chouffy/home_assistant_tgtg) fails.

Thanks!