### PR TITLE
Bump item API endpoint to v8

### DIFF
--- a/tgtg/__init__.py
+++ b/tgtg/__init__.py
@@ -12,7 +12,7 @@ from tgtg.google_play_scraper import get_last_apk_version
 from .exceptions import TgtgAPIError, TgtgLoginError, TgtgPollingError
 
 BASE_URL = "https://apptoogoodtogo.com/api/"
-API_ITEM_ENDPOINT = "item/v7/"
+API_ITEM_ENDPOINT = "item/v8/"
 AUTH_BY_EMAIL_ENDPOINT = "auth/v3/authByEmail"
 AUTH_POLLING_ENDPOINT = "auth/v3/authByRequestPollingId"
 SIGNUP_BY_EMAIL_ENDPOINT = "auth/v3/signUpByEmail"


### PR DESCRIPTION
The API endpoint v7 seems to have stopped working.