### PR TITLE
Refactor Login to Support Manual Polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ print(credentials)
 }
 ```
 
+#### No polling
+You can avoid the polling mechanism by providing the polling_id directly
+
+```python
+client = TgtgClient(email="<your_email>")
+polling_id = client.request_polling_id()
+# You now click in the link you received by email
+client.complete_login_with_polling_id(cached_polling_id)
+credentials = client.get_credentials()
+```
+
 ### Build the client from tokens
 
 ```python


### PR DESCRIPTION
When using this as a library, it will allow a more flexible login process by separating the polling ID retrieval from the automatic polling. You can now call `request_polling_id` to get the polling ID, wait for the user to click the link in the email, and then call `complete_login_with_polling_id` with the polling ID to obtain the tokens. This change maintains backward compatibility by using these new methods within the existing `login` method.

Related to issue #306 